### PR TITLE
fix: use Component to allow impure resources

### DIFF
--- a/build/mitragyna.js
+++ b/build/mitragyna.js
@@ -691,8 +691,8 @@
     value: _propTypes2.default.oneOfType([_propTypes2.default.object, _propTypes2.default.func, _propTypes2.default.string, _propTypes2.default.number])
   };
 
-  var Resource = exports.Resource = function (_React$PureComponent2) {
-    _inherits(Resource, _React$PureComponent2);
+  var Resource = exports.Resource = function (_React$Component3) {
+    _inherits(Resource, _React$Component3);
 
     function Resource(props, context) {
       _classCallCheck(this, Resource);
@@ -993,7 +993,7 @@
     }]);
 
     return Resource;
-  }(_react2.default.PureComponent);
+  }(_react2.default.Component);
 
   Resource.propTypes = {
     afterError: _propTypes2.default.func,

--- a/build/mitragyna.jsx
+++ b/build/mitragyna.jsx
@@ -529,7 +529,7 @@ export class Field extends React.Component {
   }
 }
 
-export class Resource extends React.PureComponent {
+export class Resource extends React.Component {
   static propTypes = {
     afterError: PropTypes.func,
     afterUpdate: PropTypes.func,

--- a/src/Resource.jsx
+++ b/src/Resource.jsx
@@ -1,4 +1,4 @@
-export class Resource extends React.PureComponent {
+export class Resource extends React.Component {
   static propTypes = {
     afterError: PropTypes.func,
     afterUpdate: PropTypes.func,


### PR DESCRIPTION
Since ActiveResource.js's immutable mode discards changes made to resources while they are being saved (id est: while waiting for the API server to respond), an implementation of Mitragyna is required that comes with a Resource component that allows for impure resources.

To do later: 
* Port the change tracking capabilities from ActiveResource.js over to its immutable mode (PR for vanilla AR.js coming)
* Have AR.js come with a development mode that uses deep frozen objects when in immutable mode so it's easy to recognize impurities to AR's resources
* Maybe a state manager for AR.immutable.js instead of it's vanilla object accessors?
